### PR TITLE
Add basic price comparer prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# openai
+# Price Comparer Prototype
+
+This monorepo contains a very small proof-of-concept implementation of a supermarket price comparer. It is heavily simplified and does **not** implement real scraping or authentication.
+
+## Packages
+
+- `packages/ingestion` – placeholder ingestion library. `index.js` fetches an example JSON file and normalizes product data.
+- `packages/api` – Express API with minimal `/compare`, `/search`, and `/watch` endpoints.
+- `packages/ui` – simple static site served with Express.
+
+## Development
+
+Install dependencies and start all services:
+
+```bash
+pnpm install --recursive
+node packages/api/index.js &
+node packages/ui/index.js &
+```
+
+Then open `http://localhost:3001` in your browser.
+
+**Note**: This project is a toy example and does not provide production-ready scraping or data ingestion.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "price-comparer",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["packages/*"]
+}

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import { normalizeProducts } from '@price-comparer/ingestion';
+
+const app = express();
+app.use(express.json());
+
+// Placeholder in-memory store
+const products = [];
+
+app.get('/compare', (req, res) => {
+  const { ean } = req.query;
+  const filtered = products.filter(p => p.ean === ean);
+  res.json(filtered);
+});
+
+app.get('/search', (req, res) => {
+  const { q } = req.query;
+  const filtered = products.filter(p => p.name.toLowerCase().includes(q.toLowerCase()));
+  res.json(filtered);
+});
+
+app.post('/watch', (req, res) => {
+  // TODO: implement webhook watch logic
+  res.json({ status: 'not_implemented' });
+});
+
+app.listen(3000, () => {
+  console.log('API server running on http://localhost:3000');
+});

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@price-comparer/api",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/packages/ingestion/index.js
+++ b/packages/ingestion/index.js
@@ -1,0 +1,31 @@
+import fetch from 'node-fetch';
+
+/**
+ * Fetch product data from an endpoint.
+ * For demo purposes, this uses a static JSON example.
+ */
+export async function fetchEsselungaProducts() {
+  const url = 'https://example.com/esselunga.json'; // TODO: replace with real endpoint
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch Esselunga data: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Normalize product fields: EAN, quantity, price per unit.
+ */
+export function normalizeProducts(products) {
+  return products.map(p => ({
+    ean: p.ean,
+    name: p.name,
+    price: p.price,
+    quantity: p.quantity,
+    price_per_unit: p.price / p.quantity
+  }));
+}
+
+if (require.main === module) {
+  fetchEsselungaProducts()
+    .then(data => console.log(normalizeProducts(data)))
+    .catch(err => console.error(err));
+}

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@price-comparer/ingestion",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.listen(3001, () => {
+  console.log('UI server running on http://localhost:3001');
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@price-comparer/ui",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/packages/ui/public/index.html
+++ b/packages/ui/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Price Comparer</title>
+</head>
+<body>
+  <h1>Price Comparer UI</h1>
+  <table id="prices"></table>
+  <script>
+    async function load() {
+      const res = await fetch('http://localhost:3000/compare?ean=123');
+      const data = await res.json();
+      const tbl = document.getElementById('prices');
+      tbl.innerHTML = data.map(p => `<tr><td>${p.name}</td><td>${p.price}</td></tr>`).join('');
+    }
+    load();
+  </script>
+</body>
+</html>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'


### PR DESCRIPTION
## Summary
- set up pnpm workspaces
- add ingestion placeholder script
- add express API with example endpoints
- add simple UI served via express
- document setup in README

## Testing
- `pnpm install --recursive` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_6840ba4a16cc83318212364de28e9329