### PR TITLE
Add TypeScript aggregator for Everli ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# openai
+# Price Comparer Prototype
+
+This monorepo contains a small proof-of-concept implementation of a supermarket price comparer. Some modules are placeholders and do **not** implement real scraping or authentication.
+
+## Packages
+
+- `packages/ingestion` – data ingestion utilities. `aggregator.ts` shows a minimal Everli fetch and stores results in PostgreSQL.
+- `packages/api` – Express API with minimal `/compare`, `/search`, and `/watch` endpoints.
+- `packages/ui` – simple static site served with Express.
+
+## Development
+
+Install dependencies and start all services:
+
+```bash
+pnpm install --recursive
+pnpm --filter @price-comparer/ingestion start &
+node packages/api/index.js &
+node packages/ui/index.js &
+```
+
+Then open `http://localhost:3001` in your browser.
+
+**Note**: This project is a toy example and does not provide production-ready scraping or data ingestion.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "price-comparer",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["packages/*"]
+}

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import { normalizeProducts } from '@price-comparer/ingestion';
+
+const app = express();
+app.use(express.json());
+
+// Placeholder in-memory store
+const products = [];
+
+app.get('/compare', (req, res) => {
+  const { ean } = req.query;
+  const filtered = products.filter(p => p.ean === ean);
+  res.json(filtered);
+});
+
+app.get('/search', (req, res) => {
+  const { q } = req.query;
+  const filtered = products.filter(p => p.name.toLowerCase().includes(q.toLowerCase()));
+  res.json(filtered);
+});
+
+app.post('/watch', (req, res) => {
+  // TODO: implement webhook watch logic
+  res.json({ status: 'not_implemented' });
+});
+
+app.listen(3000, () => {
+  console.log('API server running on http://localhost:3000');
+});

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@price-comparer/api",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/packages/ingestion/aggregator.ts
+++ b/packages/ingestion/aggregator.ts
@@ -1,0 +1,165 @@
+/* 
+ * Aggregatore Prezzi Grocery – MVP
+ * Linguaggio: TypeScript 5.x – Node.js 20 LTS
+ * Dipendenze chiave (da installare via pnpm / npm):
+ *   - axios            → HTTP client
+ *   - graphql-request  → Everli GraphQL wrapper
+ *   - dotenv           → env vars (solo runtime dev)
+ *   - pg               → PostgreSQL driver
+ *   - playwright-core  → scraping siti con login (Eurospin, Esselunga)
+ *   - tesseract.js     → OCR (PDF volantini)
+ *   - zx               → task runner/cron (optional)
+ *
+ * NB: questo file è un entry‑point semplificato che mostra
+ *  – fetch prezzi Everli (storeId determinato dal CAP)
+ *  – normalizzazione €/unità
+ *  – persistenza in PostgreSQL (tabella prices_history)
+ *  – gestione throttling e logging
+ */
+
+import { GraphQLClient, gql } from 'graphql-request';
+import axios from 'axios';
+import { Pool } from 'pg';
+import * as dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+
+dotenv.config();
+
+/**********************
+ * 1  · Configurazione *
+ **********************/
+const EVERLI_ENDPOINT = 'https://it.everli.com/graphql';
+const POSTAL_CODE = process.env.POSTAL_CODE ?? '20833';
+// Map statico storeId→nome (in produzione da DB)
+const STORES: Record<string, string> = {
+  '2024': 'Esselunga Monza',
+  '2158': 'Carrefour Villasanta',
+  '3367': 'Iperal Monza',
+  // aggiungi altri storeId qui
+};
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+/************************
+ * 2  · Query GraphQL    *
+ ************************/
+const productsSearch = gql`
+  query ProductsSearch($storeId: ID!, $text: String!) {
+    productsSearch(storeId: $storeId, searchText: $text, first: 50) {
+      edges {
+        node {
+          id
+          name
+          brand
+          price {
+            price
+            unitPrice
+            unitSize
+          }
+          gtin
+        }
+      }
+    }
+  }
+`;
+
+async function fetchEverli(storeId: string, keyword = 'integrale') {
+  const client = new GraphQLClient(EVERLI_ENDPOINT, {
+    headers: {
+      // Everli non richiede token per catalogo anonimo
+      'Content-Type': 'application/json',
+    },
+  });
+  const data = await client.request(productsSearch, {
+    storeId,
+    text: keyword,
+  });
+  return (
+    data?.productsSearch?.edges || []
+  ).map((e: any) => normalizeEverli(e.node, storeId));
+}
+
+/***********************************
+ * 3  · Normalizzazione SKU & price *
+ ***********************************/
+interface NormalizedPrice {
+  ean: string;
+  name: string;
+  brand: string;
+  price: number;          // prezzo confezione
+  price_per_unit: number; // €/kg o €/l già calcolato
+  unit: string;           // kg, l, ecc.
+  store_id: string;
+  captured_at: Date;
+}
+
+function normalizeEverli(node: any, storeId: string): NormalizedPrice {
+  const { gtin, name, brand, price } = node;
+  return {
+    ean: gtin,
+    name,
+    brand,
+    price: price.price,
+    price_per_unit: price.unitPrice,
+    unit: price.unitSize,
+    store_id: storeId,
+    captured_at: new Date(),
+  };
+}
+
+/****************************
+ * 4  · Persiste nel DB      *
+ ****************************/
+async function savePrices(rows: NormalizedPrice[]) {
+  const client = await pool.connect();
+  try {
+    const text = `INSERT INTO prices_history
+      (ean, store_id, price, price_per_unit, unit, captured_at)
+      VALUES ($1,$2,$3,$4,$5,$6)
+      ON CONFLICT (ean, store_id, captured_at)
+      DO NOTHING;`;
+    for (const r of rows) {
+      await client.query(text, [
+        r.ean,
+        r.store_id,
+        r.price,
+        r.price_per_unit,
+        r.unit,
+        r.captured_at,
+      ]);
+    }
+  } finally {
+    client.release();
+  }
+}
+
+/***************************
+ * 5  · Loop principale     *
+ ***************************/
+async function main() {
+  for (const [storeId, label] of Object.entries(STORES)) {
+    try {
+      console.log(`Fetching ${label}`);
+      const rows = await fetchEverli(storeId);
+      await savePrices(rows);
+      console.log(`→ salvati ${rows.length} SKU`);
+    } catch (err) {
+      console.error(`Errore store ${storeId}:`, err);
+    }
+  }
+  await pool.end();
+}
+
+main().catch(console.error);
+
+/**********************
+ * 6  · TODO prossimi  *
+ **********************/
+// • Playwright login Eurospin → estrai DOM protetto e push nel DB
+// • Glovo OAuth (Penny)      → fetch prodotti & prezzi JSON
+// • OCR volantini (Aldi)     → parse prezzo / formato
+// • Cron job (zx) ogni 5 min
+// • API GraphQL + Next.js UI

--- a/packages/ingestion/index.js
+++ b/packages/ingestion/index.js
@@ -1,0 +1,31 @@
+import fetch from 'node-fetch';
+
+/**
+ * Fetch product data from an endpoint.
+ * For demo purposes, this uses a static JSON example.
+ */
+export async function fetchEsselungaProducts() {
+  const url = 'https://example.com/esselunga.json'; // TODO: replace with real endpoint
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch Esselunga data: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Normalize product fields: EAN, quantity, price per unit.
+ */
+export function normalizeProducts(products) {
+  return products.map(p => ({
+    ean: p.ean,
+    name: p.name,
+    price: p.price,
+    quantity: p.quantity,
+    price_per_unit: p.price / p.quantity
+  }));
+}
+
+if (require.main === module) {
+  fetchEsselungaProducts()
+    .then(data => console.log(normalizeProducts(data)))
+    .catch(err => console.error(err));
+}

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@price-comparer/ingestion",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "ts-node aggregator.ts"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2",
+    "axios": "^1.6.8",
+    "graphql-request": "^6.1.0",
+    "dotenv": "^16.3.1",
+    "pg": "^8.11.3",
+    "playwright-core": "^1.41.2",
+    "tesseract.js": "^5.0.3",
+    "zx": "^7.2.3"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.listen(3001, () => {
+  console.log('UI server running on http://localhost:3001');
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@price-comparer/ui",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/packages/ui/public/index.html
+++ b/packages/ui/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Price Comparer</title>
+</head>
+<body>
+  <h1>Price Comparer UI</h1>
+  <table id="prices"></table>
+  <script>
+    async function load() {
+      const res = await fetch('http://localhost:3000/compare?ean=123');
+      const data = await res.json();
+      const tbl = document.getElementById('prices');
+      tbl.innerHTML = data.map(p => `<tr><td>${p.name}</td><td>${p.price}</td></tr>`).join('');
+    }
+    load();
+  </script>
+</body>
+</html>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'


### PR DESCRIPTION
## Summary
- document aggregator usage
- add Everli ingestion script using TypeScript
- declare ingestion dependencies and start script

## Testing
- `pnpm install --recursive` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_6840ba4a16cc83318212364de28e9329